### PR TITLE
Strong constraints

### DIFF
--- a/src/main/java/uk/ac/ox/cs/gsat/GSat.java
+++ b/src/main/java/uk/ac/ox/cs/gsat/GSat.java
@@ -14,6 +14,8 @@ import java.util.stream.Collectors;
 
 import uk.ac.ox.cs.pdq.fol.Atom;
 import uk.ac.ox.cs.pdq.fol.Dependency;
+import uk.ac.ox.cs.pdq.fol.LogicalSymbols;
+import uk.ac.ox.cs.pdq.fol.Predicate;
 import uk.ac.ox.cs.pdq.fol.TGD;
 import uk.ac.ox.cs.pdq.fol.Term;
 import uk.ac.ox.cs.pdq.fol.Variable;
@@ -225,7 +227,11 @@ public class GSat {
         Collection<Atom> fHead = new HashSet<>();
 
         for (Atom a : tgd.getHeadAtoms())
-            if (Logic.containsAny(a, eVariables))
+            if (a.equals(TGDGSat.Bottom)) {
+                // remove all head atoms since ⊥ & S ≡ ⊥ for any conjunction S
+                result.add(TGD.create(tgd.getBodyAtoms(), new Atom[] { TGDGSat.Bottom }));
+                return result;
+            } else if (Logic.containsAny(a, eVariables))
                 eHead.add(a);
             else
                 fHead.add(a);

--- a/src/main/java/uk/ac/ox/cs/gsat/TGDGSat.java
+++ b/src/main/java/uk/ac/ox/cs/gsat/TGDGSat.java
@@ -8,6 +8,8 @@ import java.util.Objects;
 import java.util.Set;
 
 import uk.ac.ox.cs.pdq.fol.Atom;
+import uk.ac.ox.cs.pdq.fol.LogicalSymbols;
+import uk.ac.ox.cs.pdq.fol.Predicate;
 import uk.ac.ox.cs.pdq.fol.TGD;
 import uk.ac.ox.cs.pdq.fol.Term;
 import uk.ac.ox.cs.pdq.fol.TypedConstant;
@@ -20,6 +22,12 @@ import uk.ac.ox.cs.pdq.fol.Variable;
 public class TGDGSat extends TGD {
 
     private static final long serialVersionUID = 1L;
+
+    /**
+     * Bottom/False We assume that LogicalSymbols.BOTTOM does not appear as a
+     * predicate symbol in the input.
+     */
+    public final static Atom Bottom = Atom.create(Predicate.create(LogicalSymbols.BOTTOM.toString(), 0));
 
     protected TGDGSat(Atom[] body, Atom[] head) {
 


### PR DESCRIPTION
Add (experimental) support for strong constraints. I assumed that ⊥ does not occur as a non-falsity predicate symbol in the input. Test cases pass. Translation to output format needs to be done, e.g. translating a derived GTGD rule `R(x1,x2) -> ⊥` into the Datalog rule `:-  R(x1,x2)`