### PR TITLE
Fix NullpointerException when unifier clashes constants

### DIFF
--- a/src/main/java/uk/ac/ox/cs/gsat/GSat.java
+++ b/src/main/java/uk/ac/ox/cs/gsat/GSat.java
@@ -39,7 +39,7 @@ public class GSat {
     }
 
     /**
-     * 
+     *
      * @return Singleton instace of GSat
      */
     public static GSat getInstance() {
@@ -47,9 +47,9 @@ public class GSat {
     }
 
     /**
-     * 
+     *
      * Main method to run the Guarded Saturation algorithm
-     * 
+     *
      * @param allDependencies the Guarded TGDs to process
      * @return the Guarded Saturation of allDependencies
      */
@@ -164,9 +164,9 @@ public class GSat {
     }
 
     /**
-     * 
+     *
      * A checker for self-join
-     * 
+     *
      * @param tgd a TGD
      * @return true if the TGD contains 2 atoms in the body or in the head with the
      *         same predicate name (needed only until we implement a generic MGU)
@@ -196,10 +196,10 @@ public class GSat {
     }
 
     /**
-     * 
+     *
      * Check if the variables we use in the rename are already used in the input
      * TGDs
-     * 
+     *
      * @param TGDs
      * @return true if it founds a variable with the same name of one of our rename
      *         variables
@@ -218,9 +218,9 @@ public class GSat {
     }
 
     /**
-     * 
+     *
      * Returns the Head Normal Form (HNF) of the input TGD
-     * 
+     *
      * @param tgd an input TGD
      * @return Head Normal Form of tgd
      */
@@ -264,9 +264,9 @@ public class GSat {
     }
 
     /**
-     * 
+     *
      * Returns the Variable Normal Form (VNF) of all the input TGDs
-     * 
+     *
      * @param tgds a collection of TGDs
      * @return Variable Normal Form of tgds
      */
@@ -277,9 +277,9 @@ public class GSat {
     }
 
     /**
-     * 
+     *
      * Returns the Variable Normal Form (VNF) of the input TGD
-     * 
+     *
      * @param tgd an input TGD
      * @return Variable Normal Form of tgd
      */
@@ -453,7 +453,7 @@ public class GSat {
     }
 
     /**
-     * 
+     *
      * @param nftgd non-full TGD (guarded)
      * @param ftgd  full TGD (guarded)
      * @return the derived rules of nftgd and ftgd according to the EVOLVE inference
@@ -500,6 +500,7 @@ public class GSat {
                         results.addAll(VNFs(HNF(TGD.create(new_body.toArray(new Atom[new_body.size()]),
                                 new_head.toArray(new Atom[new_head.size()])))));
                     }
+                    // no matching head atom for some atom in Sbody -> continue
                     continue;
                 }
 
@@ -511,6 +512,9 @@ public class GSat {
                             + Sbody + "\nS:" + S);
 
                     Map<Term, Term> mgu = getVariableSubstitution(S, Sbody);
+                    if (mgu == null)
+                        // unification failed -> continue with next sequence
+                        continue;
 
                     Collection<Atom> new_body = new HashSet<>();
                     new_body.addAll(Arrays.asList(new_nftgd.getBodyAtoms()));
@@ -522,8 +526,13 @@ public class GSat {
                     new_head.addAll(Arrays.asList(new_nftgd.getHeadAtoms()));
                     new_head.addAll(Arrays.asList(new_ftgd.getHeadAtoms()));
 
-                    results.addAll(VNFs(HNF(applyMGU(TGD.create(new_body.toArray(new Atom[new_body.size()]),
-                            new_head.toArray(new Atom[new_head.size()])), mgu))));
+                    if (mgu.isEmpty())
+                        // no need to apply the MGU
+                        results.addAll(VNFs(HNF(TGD.create(new_body.toArray(new Atom[new_body.size()]),
+                                new_head.toArray(new Atom[new_head.size()])))));
+                    else
+                        results.addAll(VNFs(HNF(applyMGU(TGD.create(new_body.toArray(new Atom[new_body.size()]),
+                                new_head.toArray(new Atom[new_head.size()])), mgu))));
 
                 }
 
@@ -600,7 +609,7 @@ public class GSat {
 
     /**
      * Mainly from https://stackoverflow.com/a/9496234
-     * 
+     *
      * @param shead
      * @return
      */
@@ -640,7 +649,9 @@ public class GSat {
                     for (int i = 0; i < headTerms.length; i++) {
                         Term bodyTerm = bodyAtom.getTerm(i);
                         Term headTerm = headTerms[i];
-                        if ((eVariables.contains(headTerm) || eVariables.contains(bodyTerm))
+                        // check if constants and existentials match
+                        if (((headTerm.isUntypedConstant() && bodyTerm.isUntypedConstant())
+                                || eVariables.contains(headTerm) || eVariables.contains(bodyTerm))
                                 && !bodyTerm.equals(headTerm)) {
                             valid = false;
                             break;

--- a/src/test/java/uk/ac/ox/cs/gsat/GSatTest.java
+++ b/src/test/java/uk/ac/ox/cs/gsat/GSatTest.java
@@ -23,7 +23,7 @@ import uk.ac.ox.cs.pdq.fol.Variable;
 
 /**
  * Unit tests for the GSat class
- * 
+ *
  * @author Stefano
  */
 public class GSatTest {
@@ -473,7 +473,34 @@ public class GSatTest {
 		expected = new HashSet<>();
 		checkEvolveNewTest(nonFull, full, expected, evolved);
 
-		// 12: Derive with a rule containing bottom. Remove all head atoms in the
+		// 12: Evolve no rule for x3 will be mapped to y1, hence R(c1,x3) needs to be
+		// unified with R(c3,y1), but c1 and c3 cannot be unified.
+		// R(x1,c1) → ∃ y1 U(x1,x2,y1) & R(c3,y1)
+		// U(x1,x2,x3) & R(c1,x3) → P(x1)
+		Atom Uc1x2y1 = Atom.create(Predicate.create("U", 3), c1, x2, y1);
+		nonFull = TGD.create(new Atom[] { Rx1c1 }, new Atom[] { Uc1x2y1, Rc3y1 });
+		Atom Rc1x3 = Atom.create(Predicate.create("R", 2), c1, x3);
+		full = TGD.create(new Atom[] { Ux1x2x3, Rc1x3 }, new Atom[] { Px1 });
+		evolved = gsat.evolveNew(nonFull, full);
+		expected = new HashSet<>();
+		checkEvolveNewTest(nonFull, full, expected, evolved);
+
+		// 13: Evolve no rule for x3 will be mapped to y1, hence R(x1,x3) & T(x1,x3)
+		// need to be unified with R(c3,y1) & T(c1,y1),
+		// but x1 cannot be mapped to c3 and c1.
+		// S(x1) → ∃ y1 U(x1,x2,y1) & R(c3,y1) & T(c1,y1)
+		// U(x1,x2,x3) & R(x1,x3) & T(x1,x3) → P(x1)
+		Atom Ux1x2y1 = Atom.create(Predicate.create("U", 3), x1, x2, y1);
+		Atom Tc1y1 = Atom.create(Predicate.create("T", 2), c1, y1);
+		nonFull = TGD.create(new Atom[] { Sx1 }, new Atom[] { Ux1x2y1, Rc3y1, Tc1y1 });
+		Atom Rx1x3 = Atom.create(Predicate.create("R", 2), x1, x3);
+		Atom Tx1x3 = Atom.create(Predicate.create("T", 2), x1, x3);
+		full = TGD.create(new Atom[] { Ux1x2x3, Rx1x3, Tx1x3 }, new Atom[] { Px1 });
+		evolved = gsat.evolveNew(nonFull, full);
+		expected = new HashSet<>();
+		checkEvolveNewTest(nonFull, full, expected, evolved);
+
+		// 14: Derive with a rule containing bottom. Remove all head atoms in the
 		// resulting rule.
 		// S(x1) -> \exists y. R(x1,y1)
 		// R(x1,x2) -> P(x1) & ⊥


### PR DESCRIPTION
Since we added support for constants, the unification of Shead and Sbody can now fail when two constants have to be unified (before that, we only had to unify universals). I added the code to handle this case and added two testcases for this scenario.